### PR TITLE
Correción ec.(9.191)

### DIFF
--- a/cap-Estabilidad-Estelar-Newtoniano.tex
+++ b/cap-Estabilidad-Estelar-Newtoniano.tex
@@ -905,7 +905,7 @@ y para la densidad media total $\bar{\rho}$ de la estrella, en $\eta=\eta_1$; ob
 \end{align}
 es decir, la densidad media ser'a proporcional a la densidad central, pues los otros factores dependen s'olo de la soluci'on a la ecuaci'on de estructura de Fermi para un $y_0$ dado (comparar con el resultado de Lane-Emden \eqref{laneemden-densidadmedia}). Y como la densidad media total de una estrella es $\bar{\rho}=M/(4\pi R^3/3)$, tendremos que la densidad central tambi'en se puede expresar en funci'on de su radio y masa total:
 \begin{equation}
-\boxed{ \rho_{\rm c}=\left(1-\frac{1}{y_0^2}\right)^{3/2}\frac{1}{4\pi}\frac{\eta_1^2\left\Vert\phi'(\eta_1)\right\Vert}{\eta_1^3}\frac{M}{R^3}.}
+\boxed{ \rho_{\rm c}= \frac{1}{4\pi}\left(1-\frac{1}{y_0^2}\right)^{3/2}\frac{\eta_1^3}{\eta_1^2\left\Vert\phi'(\eta_1)\right\Vert}\frac{M}{R^3}.}
 \end{equation}
 
 


### PR DESCRIPTION
En la ec. (9.191) se olvidó invertir el término $\eta^2 ||\phi'||/eta^3$ cuando pasa al otro lado de la ecuación.

Saludos